### PR TITLE
add getContents for html response

### DIFF
--- a/src/twigextensions/FetchTwigExtension.php
+++ b/src/twigextensions/FetchTwigExtension.php
@@ -43,6 +43,9 @@ class FetchTwigExtension extends \Twig_Extension
 
         if ($parseJson) {
             $body = json_decode($response->getBody(), true);
+        } else if (strpos($response->getHeader('content-type')[0], 'text/html') !== false) {
+			$body = (string)$response->getBody()->getContents();
+			$body = preg_replace("/\xEF\xBB\xBF/", "", $body);
         } else {
             $body = (string)$response->getBody();
         }


### PR DESCRIPTION
added autodetection for text/html response and therefore use the getContents() to return it.