### PR TITLE
Add more detailed error responses from original request

### DIFF
--- a/src/twigextensions/FetchTwigExtension.php
+++ b/src/twigextensions/FetchTwigExtension.php
@@ -55,9 +55,19 @@ class FetchTwigExtension extends \Twig_Extension
 
       } catch (\Exception $e) {
 
+        $response = $e->getResponse();
+
+        if ($parseJson) {
+          $body = json_decode($response->getBody(), true);
+        } else {
+          $body = (string)$response->getBody();
+        }
+
         return [
           'error' => true,
-          'reason' => $e->getMessage()
+          'statusCode' => $response->getStatusCode(),
+          'reason' => $e->getMessage(),
+          'body' => $body
         ];
 
       }


### PR DESCRIPTION
Use case:  
For an API request that responds back with detailed error messages for how to correct an issue, or exactly what went wrong, it would be nice to have the original response body returned when an Exception is thrown.

I also chose to add the status code from the HTTP request as well. A good example of this would be to display different messages to the user in a template for why the request failed.

My specific use case for this is searching for a term in an API. If the term is not found the API responds with 404, since the resource could not be found. I wanted to be able to handle this on the front end:  
```twig
{% if response.statusCode == 404 %}
    <p class="text-warning">Record not found name {{record}} not found</p>
{% elseif response.statusCode == 400 %}
    <p class="text-danger">Record type is not supported</p>
{% else %}
    <p class="text-danger">{{error|json_encode(constant('JSON_PRETTY_PRINT'))}}</p>
{% endif %}
```

---

Side notes:  
I didn't see any documentation on contributing to this project. Hoping this is okay.